### PR TITLE
chore: lateral modal

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -48,9 +48,9 @@ const meta: Meta<typeof Modal> = {
       control: "text",
     },
     type: {
-      description: "default | full-screen | web | form",
+      description: "default | full-screen | web | form | lateral",
       control: "select",
-      options: ["default", "full-screen", "web", "form"],
+      options: ["default", "full-screen", "web", "form ", "lateral"],
       table: {
         defaultValue: { summary: "default" },
       },
@@ -105,6 +105,32 @@ export const Default: Story = {
 export const FullScreen: Story = {
   args: {
     type: "full-screen",
+  },
+  render: (args) => {
+    const [isVisible, setIsVisible] = useState(false);
+    return (
+      <div>
+        <button role="button" onClick={() => setIsVisible(true)}>
+          Show modal
+        </button>
+        <Modal
+          {...args}
+          isVisible={isVisible}
+          onClose={() => {
+            setIsVisible(false);
+            action("onClose")();
+          }}
+        >
+          <Text type="p">Modal children</Text>
+        </Modal>
+      </div>
+    );
+  },
+};
+
+export const Lateral: Story = {
+  args: {
+    type: "lateral",
   },
   render: (args) => {
     const [isVisible, setIsVisible] = useState(false);

--- a/src/components/Modal/ModalPrimary.tsx
+++ b/src/components/Modal/ModalPrimary.tsx
@@ -55,12 +55,25 @@ const ModalComponent = forwardRef(
 	(props: ModalPrimaryProps, ref: Ref<ModalRef>) => {
 		const [isVisible, setIsVisible] = useState(props.isVisible);
 		const [show, setShow] = useState(false);
+		const [isLargeScreen, setIsLargeScreen] = useState(false);
 
 		useImperativeHandle(ref, () => ({
 			close() {
 				onClose();
 			},
 		}));
+
+		useEffect(() => {
+			const mediaQuery = window.matchMedia("(min-width: 768px)"); 
+			setIsLargeScreen(mediaQuery.matches); 
+
+			const handleResize = (e: MediaQueryListEvent) => {
+				setIsLargeScreen(e.matches);
+			};
+
+			mediaQuery.addListener(handleResize);
+			return () => mediaQuery.removeListener(handleResize);
+		}, []);
 
 		useEffect(() => {
 			//Open
@@ -100,12 +113,24 @@ const ModalComponent = forwardRef(
 				style={{
 					content: {
 						position: "absolute",
-						width: props.type === "full-screen" ? "100%" : 500,
+						width:
+							props.type === "full-screen"
+								? "100%"
+								: props.type === "lateral"
+								? isLargeScreen
+									? "400px"  
+									: "100%"  
+								: 500,
 						maxWidth:
 							props.type === "full-screen"
 								? "100%"
+								: props.type === "lateral"
+								? isLargeScreen
+									? "400px"  
+									: "100%"  
 								: "calc(100% - 0px)",
-						maxHeight: "90%",
+						height: props.type === "lateral" ? "100%" : undefined,
+						maxHeight: props.type === "web" ? "90%" : "100%",
 						background: "#FFFFFF",
 						boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)",
 						borderRadius:
@@ -113,7 +138,9 @@ const ModalComponent = forwardRef(
 								? "12px 12px 0px 0px"
 								: 12,
 						top:
-							props.type !== "full-screen"
+							props.type === "lateral"
+								? "0"
+								: props.type !== "full-screen"
 								? show
 									? "50%"
 									: "150%"
@@ -124,15 +151,30 @@ const ModalComponent = forwardRef(
 									? "0px"
 									: "-100vh"
 								: "unset",
+						right:
+							props.type === "lateral"
+								? show
+									? "0"
+									: "-100vw"
+								: "unset",
 						transition:
-							"top 0.3s ease-out, bottom 0.3s ease-out, transform 0.3s ease-in-out",
-						left: "50%",
+							props.type === "lateral"
+								? "right 0.3s ease-out, transform 0.3s ease-in-out"
+								: "top 0.3s ease-out, bottom 0.3s ease-out, transform 0.3s ease-in-out",
+						left:
+							props.type === "lateral"
+								? "unset"
+								: props.type === "full-screen"
+								? "50%"
+								: "50%",
 						transform:
 							props.type === "full-screen"
 								? "translate(-50%, 0%)"
+								: props.type === "lateral"
+								? "translate(0, 0)"
 								: "translate(-50%, -50%) scale(" +
-									(show ? 1 : 0.2) +
-									")",
+								  (show ? 1 : 0.2) +
+								  ")",
 						overflow: "hidden",
 						overflowY: "auto",
 						border: "none",
@@ -210,12 +252,13 @@ const ModalComponent = forwardRef(
 				)}
 			</Modal>
 		);
-	},
+	}
 );
 export default ModalComponent;
+
 export interface ModalPrimaryProps extends ComponentPropsWithoutRef<"div"> {
 	isVisible: boolean;
-	type?: "default" | "full-screen" | "form" | "web";
+	type?: "default" | "full-screen" | "form" | "web" | "lateral";
 	title?: string;
 	subtitle?: string;
 	error?: string;

--- a/src/components/Modal/ModalPrimary.tsx
+++ b/src/components/Modal/ModalPrimary.tsx
@@ -23,9 +23,6 @@ const TitleView = styled.div`
 	top: 0px;
 	background-color: white;
 	z-index: 100;
-	${media.lessThan("small")`
-        padding: 0px;
-    `}
 `;
 const ChildrenView = styled.div`
 	padding: 0px 24px;
@@ -64,8 +61,8 @@ const ModalComponent = forwardRef(
 		}));
 
 		useEffect(() => {
-			const mediaQuery = window.matchMedia("(min-width: 768px)"); 
-			setIsLargeScreen(mediaQuery.matches); 
+			const mediaQuery = window.matchMedia("(min-width: 768px)");
+			setIsLargeScreen(mediaQuery.matches);
 
 			const handleResize = (e: MediaQueryListEvent) => {
 				setIsLargeScreen(e.matches);
@@ -108,7 +105,9 @@ const ModalComponent = forwardRef(
 				role="modal"
 				isOpen={isVisible}
 				onRequestClose={onClose}
-				shouldCloseOnOverlayClick={props.shouldCloseOnOverlayClick ?? false}
+				shouldCloseOnOverlayClick={
+					props.shouldCloseOnOverlayClick ?? false
+				}
 				ariaHideApp={false}
 				style={{
 					content: {
@@ -118,24 +117,26 @@ const ModalComponent = forwardRef(
 								? "100%"
 								: props.type === "lateral"
 								? isLargeScreen
-									? "400px"  
-									: "100%"  
+									? "400px"
+									: "100%"
 								: 500,
 						maxWidth:
 							props.type === "full-screen"
 								? "100%"
 								: props.type === "lateral"
 								? isLargeScreen
-									? "400px"  
-									: "100%"  
-								: "calc(100% - 0px)",
+									? "400px"
+									: "100%"
+								: "90%",
 						height: props.type === "lateral" ? "100%" : undefined,
-						maxHeight: props.type === "web" ? "90%" : "100%",
+						maxHeight: props.type === "lateral" ? "100%" : "90%",
 						background: "#FFFFFF",
 						boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)",
 						borderRadius:
 							props.type === "full-screen"
 								? "12px 12px 0px 0px"
+								: props.type === "lateral"
+								? 0
 								: 12,
 						top:
 							props.type === "lateral"


### PR DESCRIPTION
Por un lado he creado el modal lateral, por otro ajustado una cosa de la altura porque quiero que el modal me ocupe toda la altura pero en el modal de web por ejemplo la altura es de 90% y ya está arreglado, y por otro lado quería hacer que el móvil ocupase toda la pantalla pero en escritorio que fuera un pequeño modal saliente, que creo que es lo suyo.