### PR TITLE
chore: add prop shape to Filter's Checkbox

### DIFF
--- a/src/components/Filter/FilterCheckbox.tsx
+++ b/src/components/Filter/FilterCheckbox.tsx
@@ -117,6 +117,7 @@ const FilterCheckbox = forwardRef(
 					options={optionsState}
 					selectedOptions={checkboxSelection}
 					type={type}
+					shape={restProps.shape}
 					height={isMobile ? 22 : 18}
 					width={isMobile ? 22 : 18}
 					position={isMobile ? "right" : "left"}
@@ -135,6 +136,7 @@ export interface FilterCheckboxProps {
 	hideSearchBar?: boolean;
 	style?: CSSProperties;
 	type: "single" | "multiple";
+	shape?: "circle" | "square";
 	options: Array<{
 		id: string;
 		label: string;


### PR DESCRIPTION
A las checkBoxes de los filters les faltaba añadir el poder elegir la forma del check, circulo o cuadrado